### PR TITLE
Update CLI tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
-"""Tests for the gitingest cli."""
+"""Tests for the gitingest CLI."""
 
 import os
+from unittest.mock import patch
 
 from click.testing import CliRunner
 
@@ -8,34 +9,56 @@ from gitingest.cli import main
 from gitingest.config import MAX_FILE_SIZE, OUTPUT_FILE_NAME
 
 
+async def _stub_ingest_async(
+    source: str,
+    max_file_size: int = MAX_FILE_SIZE,
+    include_patterns=None,
+    exclude_patterns=None,
+    branch=None,
+    output: str | None = None,
+):
+    path = output or OUTPUT_FILE_NAME
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("dummy")
+    return "summary", "tree", "content"
+
+
 def test_cli_with_default_options():
     runner = CliRunner()
-    result = runner.invoke(main, ["./"])
-    output_lines = result.output.strip().split("\n")
-    assert f"Analysis complete! Output written to: {OUTPUT_FILE_NAME}" in output_lines
-    assert os.path.exists(OUTPUT_FILE_NAME), f"Output file was not created at {OUTPUT_FILE_NAME}"
-
-    os.remove(OUTPUT_FILE_NAME)
+    with runner.isolated_filesystem():
+        with patch("gitingest.cli.ingest_async", new=_stub_ingest_async):
+            result = runner.invoke(main, ["./"])
+        output_lines = result.output.strip().split("\n")
+        assert (
+            f"Analysis complete! Output written to: {OUTPUT_FILE_NAME}" in output_lines
+        )
+        assert os.path.exists(
+            OUTPUT_FILE_NAME
+        ), f"Output file was not created at {OUTPUT_FILE_NAME}"
 
 
 def test_cli_with_options():
     runner = CliRunner()
-    result = runner.invoke(
-        main,
-        [
-            "./",
-            "--output",
-            str(OUTPUT_FILE_NAME),
-            "--max-size",
-            str(MAX_FILE_SIZE),
-            "--exclude-pattern",
-            "tests/",
-            "--include-pattern",
-            "src/",
-        ],
-    )
-    output_lines = result.output.strip().split("\n")
-    assert f"Analysis complete! Output written to: {OUTPUT_FILE_NAME}" in output_lines
-    assert os.path.exists(OUTPUT_FILE_NAME), f"Output file was not created at {OUTPUT_FILE_NAME}"
-
-    os.remove(OUTPUT_FILE_NAME)
+    with runner.isolated_filesystem():
+        with patch("gitingest.cli.ingest_async", new=_stub_ingest_async):
+            result = runner.invoke(
+                main,
+                [
+                    "./",
+                    "--output",
+                    str(OUTPUT_FILE_NAME),
+                    "--max-size",
+                    str(MAX_FILE_SIZE),
+                    "--exclude-pattern",
+                    "tests/",
+                    "--include-pattern",
+                    "src/",
+                ],
+            )
+        output_lines = result.output.strip().split("\n")
+        assert (
+            f"Analysis complete! Output written to: {OUTPUT_FILE_NAME}" in output_lines
+        )
+        assert os.path.exists(
+            OUTPUT_FILE_NAME
+        ), f"Output file was not created at {OUTPUT_FILE_NAME}"


### PR DESCRIPTION
## Summary
- isolate CLI tests from filesystem
- stub ingest_async in CLI unit tests

## Testing
- `pytest tests/test_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f018a50883309dae0a9dcee04c6f