### PR TITLE
Update pre-commit hooks and docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
       - id: black
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.1
+    rev: v3.20.0
     hooks:
       - id: pyupgrade
         description: "Automatically upgrade syntax for newer versions."
@@ -73,7 +73,7 @@ repos:
       - id: djlint-reformat-jinja
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.44.0
+    rev: v0.45.0
     hooks:
       - id: markdownlint
         description: "Lint markdown files."
@@ -88,7 +88,7 @@ repos:
         files: ^src/
 
   - repo: https://github.com/pycqa/pylint
-    rev: v3.3.6
+    rev: v3.3.7
     hooks:
       - id: pylint
         name: pylint for source
@@ -124,6 +124,16 @@ repos:
             tomli,
             uvicorn>=0.11.7,
           ]
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.16.0
+    hooks:
+      - id: mypy
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.13
+    hooks:
+      - id: ruff
 
   - repo: meta
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,8 +25,11 @@ Thanks for your interest in contributing to Gitingest! 🚀 Gitingest aims to be
    python -m venv .venv
    source .venv/bin/activate
    pip install -r requirements-dev.txt
-   pre-commit install
+   pre-commit install  # mandatory
    ```
+
+   Running `pre-commit install` is required so that the git hooks are executed
+   every time you commit changes.
 
 4. Create a new branch for your changes:
 


### PR DESCRIPTION
## Summary
- autoupdate pre-commit hooks
- add `mypy` and `ruff` hooks
- mention that running `pre-commit install` is mandatory

## Testing
- `pre-commit run --files .pre-commit-config.yaml CONTRIBUTING.md`

------
https://chatgpt.com/codex/tasks/task_e_6845afc521b88330812d897f7282d8aa