### PR TITLE
Fix typo in limit_exceeded message

### DIFF
--- a/src/gitingest/ingestion.py
+++ b/src/gitingest/ingestion.py
@@ -314,7 +314,7 @@ def limit_exceeded(stats: FileSystemStats, depth: int) -> bool:
         return True  # TODO: end recursion
 
     if stats.total_size >= MAX_TOTAL_SIZE_BYTES:
-        print(f"Maxumum total size limit ({MAX_TOTAL_SIZE_BYTES/1024/1024:.1f}MB) reached")
+        print(f"Maximum total size limit ({MAX_TOTAL_SIZE_BYTES/1024/1024:.1f}MB) reached")
         return True  # TODO: end recursion
 
     return False


### PR DESCRIPTION
## Summary
- fix typo in `limit_exceeded`

## Testing
- `pre-commit run --files src/gitingest/ingestion.py`
- `pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6844f00688e08330b5dfed3311a5fd70