### PR TITLE
Fix packaging and chunking fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.10', '3.12']
+        python-version: ['3.9', '3.10', '3.12']
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,11 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends gcc python3-dev \
     && pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir --timeout 1000 -r requirements.txt \
+    && python - <<'EOF'
+import tree_sitter_languages
+for lang in ["python", "javascript"]:
+    tree_sitter_languages.get_parser(lang)
+EOF
     && rm -rf /var/lib/apt/lists/*
 
 # Runtime stage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "gitingest"
 version = "0.3.0"
 description="CLI tool to analyze and create text dumps of codebases for LLMs"
 readme = {file = "README.md", content-type = "text/markdown" }
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 dependencies = [
     "click>=8.0.0",
     "fastapi[standard]>=0.110.0",  # security fix
@@ -46,6 +46,9 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools]
 packages = {find = {where = ["src"]}}
 include-package-data = true
+
+[tool.setuptools.package-data]
+"gitingest.chunking.languages" = ["*.scm"]
 
 # Linting configuration
 [tool.pylint.format]

--- a/requirements.in
+++ b/requirements.in
@@ -8,4 +8,4 @@ tiktoken
 tomli
 uvicorn>=0.29.0
 tree_sitter==0.20.2
-tree_sitter_languages==1.10.0
+tree_sitter_languages==1.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -961,4 +961,4 @@ wrapt==1.17.2 \
     --hash=sha256:ff04ef6eec3eee8a5efef2401495967a916feaa353643defcc03fc74fe213b58
     # via deprecated
 tree_sitter==0.20.2
-tree_sitter_languages==1.10.0
+tree_sitter_languages==1.10.1

--- a/src/gitingest/chunking/chunker.py
+++ b/src/gitingest/chunking/chunker.py
@@ -21,7 +21,11 @@ def _split_long(text: str, max_lines: int):
 def chunk_file(path: Path, max_lines: int = 400) -> list[Chunk]:
     lang_name = get_lang_from_path(path)
     if not lang_name:
-        return [Chunk(str(path), 0, "file", path.read_text())]
+        try:
+            text = path.read_text()
+        except UnicodeDecodeError:
+            text = "[Non-text file]"
+        return [Chunk(str(path), 0, "file", text)]
 
     parser, query = build_parser(lang_name)
     source = path.read_bytes()
@@ -42,7 +46,11 @@ def chunk_file(path: Path, max_lines: int = 400) -> list[Chunk]:
             idx += 1
 
     if not chunks:
-        chunks.append(Chunk(str(path), 0, "file", source.decode()))
+        try:
+            text = source.decode()
+        except UnicodeDecodeError:
+            text = "[Non-text file]"
+        chunks.append(Chunk(str(path), 0, "file", text))
     return chunks
 
 


### PR DESCRIPTION
## Summary
- include .scm queries in wheels
- bump minimum Python version and CI matrix
- precompile Tree-sitter grammars in Docker build
- pin tree_sitter_languages and update requirements
- handle binary files in `chunk_file`

## Testing
- `pip install -r requirements.txt --require-hashes` *(fails: missing hashes)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tiktoken')*

------
https://chatgpt.com/codex/tasks/task_e_6845feb643f88330a31e31daad533640