### PR TITLE
Fix tests to avoid network ops

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,6 +19,7 @@ async def _stub_ingest_async(
     parallel: bool = False,
     incremental: bool = False,
     compress: bool = False,
+    stream: bool = False,
 ):
     # pylint: disable=unused-argument,too-many-arguments
     path = output or OUTPUT_FILE_NAME


### PR DESCRIPTION
## Summary
- avoid network call in clone_specific_branch test
- patch correct fetch_remote_branch_list in query parser tests
- update CLI test stub for new parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68462e09c36c83308f241878cf37cbdf