### PR TITLE
Implement JSONL output

### DIFF
--- a/src/gitingest/cli.py
+++ b/src/gitingest/cli.py
@@ -26,6 +26,7 @@ from gitingest.output_utils import write_digest
 @click.option("--incremental", is_flag=True, help="Use disk cache to skip unchanged files")
 @click.option("--compress", is_flag=True, help="Write gzip compressed output")
 @click.option("--stream", is_flag=True, help="Download via GitHub API instead of git")
+@click.option("--format", "-f", "output_format", type=click.Choice(['text', 'jsonl']), default='text', help="The output format for the digest.")
 def main(
     source: str,
     output: str,
@@ -37,6 +38,7 @@ def main(
     incremental: bool,
     compress: bool,
     stream: bool,
+    output_format: str,
 ) -> None:
     """Main entry point for the CLI."""
     asyncio.run(
@@ -51,6 +53,7 @@ def main(
             incremental,
             compress,
             stream,
+            output_format,
         )
     )
 
@@ -66,6 +69,7 @@ async def _async_main(
     incremental: bool,
     compress: bool,
     stream: bool,
+    output_format: str,
 ) -> None:
     """Analyze a directory or repository and create a text dump of its contents."""
     try:
@@ -83,6 +87,7 @@ async def _async_main(
             incremental=incremental,
             compress=compress,
             stream=stream,
+            output_format=output_format,
         )
 
         text = tree + "\n" + content

--- a/src/gitingest/entrypoint.py
+++ b/src/gitingest/entrypoint.py
@@ -24,6 +24,7 @@ async def ingest_async(
     incremental: bool = False,
     compress: bool = False,
     stream: bool = False,
+    output_format: str = "text",
 ) -> Tuple[str, str, str]:
     # pylint: disable=unused-argument
     """
@@ -86,6 +87,7 @@ async def ingest_async(
             include_patterns=include_patterns,
             ignore_patterns=exclude_patterns,
         )
+        query.output_format = output_format
 
         if query.url:
             selected_branch = branch if branch else query.branch
@@ -113,7 +115,7 @@ async def ingest_async(
 
             repo_cloned = True
 
-        summary, tree, content = ingest_query(query)
+        summary, tree, content = ingest_query(query, output_format=output_format)
 
         if output is not None:
             from gitingest.output_utils import write_digest  # pylint: disable=C0415
@@ -138,6 +140,7 @@ def ingest(
     incremental: bool = False,
     compress: bool = False,
     stream: bool = False,
+    output_format: str = "text",
 ) -> Tuple[str, str, str]:
     """
     Synchronous version of ingest_async.
@@ -186,5 +189,6 @@ def ingest(
             incremental=incremental,
             compress=compress,
             stream=stream,
+            output_format=output_format,
         )
     )

--- a/src/gitingest/output_utils.py
+++ b/src/gitingest/output_utils.py
@@ -4,23 +4,6 @@ import gzip
 from pathlib import Path
 
 
-def write_digest(text: str, path: Path, compress: bool = False) -> None:
-    """Write a digest to ``path``; gzip if ``compress`` is True.
-
-    Parameters
-    ----------
-    text : str
-        Digest text to write.
-    path : Path
-        Destination path.
-    compress : bool, optional
-        If ``True``, write gzip-compressed output.
-    """
-    if compress:
-        with gzip.open(path.with_suffix(".gz"), "wt", compresslevel=9) as f:
-            f.write(text)
-    else:
-        path.write_text(text)
 
 def write_digest(text: str, path: Path, compress: bool = False) -> None:
     """Write text to a path optionally gzipped."""
@@ -30,3 +13,4 @@ def write_digest(text: str, path: Path, compress: bool = False) -> None:
             f.write(text)
     else:
         path.write_text(text, encoding="utf-8")
+

--- a/src/gitingest/schemas/ingestion_schema.py
+++ b/src/gitingest/schemas/ingestion_schema.py
@@ -66,6 +66,7 @@ class IngestionQuery(BaseModel):  # pylint: disable=too-many-instance-attributes
     max_file_size: int = Field(default=MAX_FILE_SIZE)
     ignore_patterns: Optional[Set[str]] = None
     include_patterns: Optional[Set[str]] = None
+    output_format: str = "text"
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 


### PR DESCRIPTION
## Summary
- add `--format` CLI option to switch between `text` and new `jsonl` output
- thread output_format through entrypoints and ingestion logic
- support `jsonl` generation via `_gather_file_contents_jsonl`
- add `output_format` field on `IngestionQuery`
- remove duplicated function from `output_utils`

## Testing
- `pytest -q` *(fails: TypeError: __init__() takes exactly 1 argument (2 given))*

------
https://chatgpt.com/codex/tasks/task_e_684a4351df1083308d372b5bc637cbff