### PR TITLE
Refactor write_digest and update CLI

### DIFF
--- a/src/gitingest/cli.py
+++ b/src/gitingest/cli.py
@@ -4,7 +4,6 @@
 
 import asyncio
 import os
-import gzip
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -86,14 +85,17 @@ async def _async_main(
         )
 
         text = tree + "\n" + content
+        output_path = Path(output)
+
+        # Single call to our robust utility function
+        write_digest(text, output_path, compress)
+
+        # Determine the final output name for the user message
         if compress:
-            gz_path = Path(str(output) + ".gz")
-            with gzip.open(gz_path, "wt", encoding="utf-8") as f:
-                f.write(text)
-            out_name = str(gz_path)
+            out_name = str(output_path) + ".gz"
         else:
-            write_digest(text, Path(output), compress=False)
-            out_name = str(output)
+            out_name = str(output_path)
+
         click.echo(f"Analysis complete! Output written to: {out_name}")
         click.echo("\nSummary:")
         click.echo(summary)

--- a/src/gitingest/output_utils.py
+++ b/src/gitingest/output_utils.py
@@ -14,19 +14,12 @@ def write_digest(text: str, path: Path, compress: bool = False) -> None:
     path : Path
         Destination path.
     compress : bool, optional
-        If ``True``, write gzip-compressed output.
+        If ``True``, write gzip-compressed output, appending .gz to the path.
     """
     if compress:
-        with gzip.open(path.with_suffix(".gz"), "wt", compresslevel=9) as f:
-            f.write(text)
-    else:
-        path.write_text(text)
-
-def write_digest(text: str, path: Path, compress: bool = False) -> None:
-    """Write text to a path optionally gzipped."""
-    if compress:
-        gz_path = path.with_suffix(".gz")
-        with gzip.open(gz_path, "wt", encoding="utf-8") as f:
+        # Append .gz to the original filename to preserve extensions like .jsonl
+        gz_path = Path(str(path) + ".gz")
+        with gzip.open(gz_path, "wt", encoding="utf-8", compresslevel=9) as f:
             f.write(text)
     else:
         path.write_text(text, encoding="utf-8")


### PR DESCRIPTION
## Summary
- consolidate duplicated `write_digest` helper
- simplify CLI output handling using the new utility

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q tree_sitter_languages`
- `pytest -q` *(fails: `TypeError: __init__() takes exactly 1 argument (2 given)`)*

------
https://chatgpt.com/codex/tasks/task_e_684a451175dc83309668a4128a7c7aa0