### PR TITLE
Add Go language chunking support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
     && pip install --no-cache-dir --timeout 1000 -r requirements.txt \
     && python - <<'EOF'
 import tree_sitter_languages
-for lang in ["python", "javascript"]:
+for lang in ["python", "javascript", "go"]:
     tree_sitter_languages.get_parser(lang)
 EOF
     && rm -rf /var/lib/apt/lists/*

--- a/src/gitingest/chunking/language_registry.py
+++ b/src/gitingest/chunking/language_registry.py
@@ -1,27 +1,53 @@
 """Helper utilities for mapping file extensions to Tree-sitter parsers."""
 
 from pathlib import Path
+
 from tree_sitter_languages import get_language, get_parser
 
 LANGUAGE_QUERIES = {
     "python": "languages/python.scm",
     "javascript": "languages/javascript.scm",
+    "go": "languages/go.scm",  # <-- ADDED
 }
 
 EXT_TO_LANG = {
     ".py": "python",
     ".js": "javascript",
     ".ts": "javascript",
+    ".go": "go",  # <-- ADDED
 }
 
-def get_lang_from_path(path: Path):
-    """Return language name for ``path`` based on its extension."""
+
+def get_lang_from_path(path: Path) -> str | None:
+    """Return the registered language for a given file path.
+
+    Parameters
+    ----------
+    path : Path
+        File path to inspect.
+
+    Returns
+    -------
+    str | None
+        The detected language name, or ``None`` if the extension is unknown.
+    """
 
     return EXT_TO_LANG.get(path.suffix.lower())
 
 
 def build_parser(language_name: str):
-    """Build a Tree-sitter parser and query for ``language_name``."""
+    """Build and return a Tree-sitter parser and query for a language.
+
+    Parameters
+    ----------
+    language_name : str
+        The language key as defined in :data:`LANGUAGE_QUERIES`.
+
+    Returns
+    -------
+    tuple
+        The initialized ``Parser`` instance and compiled ``Query``.
+    """
 
     lang = get_language(language_name)
     parser = get_parser(language_name)

--- a/src/gitingest/chunking/languages/go.scm
+++ b/src/gitingest/chunking/languages/go.scm
@@ -1,0 +1,5 @@
+; Capture Go functions and methods
+
+(function_declaration) @function
+
+(method_declaration) @method


### PR DESCRIPTION
## Summary
- add Tree-sitter patterns for Go
- register Go in `language_registry`
- precompile Go parser in Docker build

## Testing
- `pre-commit run --files src/gitingest/chunking/language_registry.py src/gitingest/chunking/languages/go.scm Dockerfile` *(fails: Unable to import 'tree_sitter_languages' in pylint)*
- `pytest` *(fails: TypeError: __init__() takes exactly 1 argument (2 given))*

------
https://chatgpt.com/codex/tasks/task_e_684a44c30548833090343f73d718e9fd